### PR TITLE
feat: avoid rerequesting reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # auto-release-dev-stage-prod-testing
 
-change
+GitHub Action that assigns reviewers to a Pull Request based on the authors of commits in the PR.
+
+## Testing
+
+You can run the action locally by running `manual-test`.
+See `src/tests/test.ts` for input configuration.
+
+You need a GitHub Personal Access Token as an environment variable in `GITHUB_TOKEN` to run it.
+
+```
+npm run manual-test
+```

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "tsc && ncc build lib/index.js",
+    "manual-test": "tsc && node lib/tests/test.js",
     "prepare": "husky"
   },
   "author": "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ async function run() {
       number,
       token,
       debug: core.debug,
+      info: core.info,
       owner: context.repo.owner,
       repo: context.repo.repo,
       userLogin,

--- a/src/tests/test.ts
+++ b/src/tests/test.ts
@@ -1,0 +1,17 @@
+import { assignReviewers } from "../assignReviewers";
+
+async function run() {
+  const authors = await assignReviewers({
+    owner: "understory-io",
+    repo: "backoffice",
+    number: 2192,
+    debug: (m: string) => console.log("DEBUG: " + m),
+    info: console.log,
+    userLogin: "foo",
+    token: process.env.GITHUB_TOKEN || "",
+  });
+
+  console.log(authors);
+}
+
+run();


### PR DESCRIPTION
Small expansion of the logic around selecting reviewers.

Currently, the action will re-request reviews for all authors. This means that if John and Jane are both authors of a PR but John reviews the PR while Jane adds additional commits, John would get another request to review.

This change fetches reviewers before assigning and filters any already approved authors out.

I also made a small manual test file to run it locally against specific PRs for testing.