### PR TITLE
chore(ci): move GitHub Actions onto Node 24 runtimes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ inputs:
 #   time: # id of output
 #     description: "The time we greeted you"
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
## Why

The runner now reports:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24.

GitHub no longer honours the runtime an action declares — Node 20 bundles are already being executed on Node 24. These bumps put each action on a version actually built for that engine.

Part of an org-wide sweep; see understory-io/infrastructure-iam-core#157 for the full analysis.

## Changed in this repo
This action declares its own runtime, so no amount of bumping callers fixes it — `action.yml` moves from `using: "node20"` to `using: "node24"`.

`dist/index.js` was rebuilt (`npm ci && npm run build`) and came out byte-identical, so the only behavioural change is the declared runtime. `npm test` passes (6/6).

⚠️ Both consumers — `infrastructure-core` and `infrastructure-stripe` — pin this action at `@main`, so the change lands for them the moment this merges.## Verification

- Runtimes read from each tag's `action.yml`, not from release notes — the majors do not line up between actions (`github-script@v7` is Node 20 while `checkout@v7` is Node 24).
- Every target major was checked for behavioural breaking changes beyond the runtime bump.
- All jobs touched here run on GitHub-hosted runners, well past the 2.327.1 minimum the Node 24 actions require.

🤖 Generated with [Claude Code](https://claude.com/claude-code)